### PR TITLE
Fix digital rain resize behavior

### DIFF
--- a/themes/AUTHOR/assets/js/main.js
+++ b/themes/AUTHOR/assets/js/main.js
@@ -238,7 +238,7 @@ function createDigitalRain() {
   canvas.height = window.innerHeight;
   
   const chars = '01アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン';
-  const columns = Math.floor(canvas.width / 20);
+  let columns = Math.floor(canvas.width / 20);
   const drops = [];
   
   for (let i = 0; i < columns; i++) {
@@ -295,6 +295,9 @@ function createDigitalRain() {
       // Remove excess drops
       drops.length = newColumns;
     }
+
+    // Update stored columns count
+    columns = newColumns;
     
     // Restart animation
     animate();


### PR DESCRIPTION
## Summary
- maintain column count in digital rain effect after window resize

## Testing
- `node --check themes/AUTHOR/assets/js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_684b328947bc8327be7c6edeb26c6395