### PR TITLE
Add inquiries page and SEO tags

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -2,6 +2,7 @@
 title = 'Home'
 date = 2025-03-30T08:00:00-07:00
 draft = false
+description = 'Speculative fiction author exploring technology and spirituality through books, stories, and immersive audio.'
 +++
 
 ## Jeffrey A. Zyjeski

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -2,6 +2,7 @@
 title = 'About'
 date = 2025-03-30T08:00:00-07:00
 draft = false
+description = 'Bio and contact information for speculative fiction author Jeffrey A. Zyjeski.'
 +++
 
 ## Jeffrey A. Zyjeski

--- a/content/audio/_index.md
+++ b/content/audio/_index.md
@@ -2,5 +2,6 @@
 title: Simulations
 date: 2025-03-30T15:00:00.000Z
 draft: false
+description: Audio experiences merging meditation with dystopian narrative.
 ---
 Audio experiences that merge meditation with dystopian narrative. These journeys blur the line between spiritual practice and speculative fiction, creating immersive mindscapes that challenge the listener's perception of reality.

--- a/content/audio/first-simulation/index.md
+++ b/content/audio/first-simulation/index.md
@@ -3,6 +3,7 @@ title = 'Guided Neural Rebooting Protocol'
 date = 2025-03-15T14:00:00-07:00
 draft = false
 audio_file = '/audio/neural-reboot-simulation.mp3'
+description = 'Guided meditation audio for rebooting ordinary consciousness.'
 transcript = '''
 
 Begin by focusing your awareness on the sound of my voice. Notice how each word is both sound wave and data packet—vibration and information simultaneously.

--- a/content/audio/spoken-story-one.md
+++ b/content/audio/spoken-story-one.md
@@ -4,6 +4,7 @@ date = 2025-04-30T15:00:00.000Z
 draft = false
 externalLink = "https://ihave.spoken.press/p/P6q4ODkJMLk"
 image = "/images/uploads/first-spoken-story.png"
+description = "Audio story hosted on spoken.press featuring the character Bart Higgins."
 +++
 
 This is a spoken.press audio story. You will be redirected to the external site.

--- a/content/audio/spoken-story-three.md
+++ b/content/audio/spoken-story-three.md
@@ -4,6 +4,7 @@ date = 2025-04-30T15:00:00.000Z
 draft = false
 externalLink = "https://ihave.spoken.press/p/SQGC999dek_"
 image = "/images/uploads/third-spoken-story.png"
+description = "Spoken.press audio story titled The Living Librarian."
 +++
 
 This is a spoken.press audio story. You will be redirected to the external site.

--- a/content/audio/spoken-story-two.md
+++ b/content/audio/spoken-story-two.md
@@ -4,6 +4,7 @@ date = 2025-04-30T15:00:00.000Z
 draft = false
 externalLink = "ihave.spoken.press/p/Kr1T8B0T9ZE"
 image = "/images/uploads/second-spoken-story.png"
+description = "Spoken.press audio story following the adventures of Quantum Bill."
 +++
 
 This is a spoken.press audio story. You will be redirected to the external site.

--- a/content/books/_index.md
+++ b/content/books/_index.md
@@ -4,5 +4,6 @@ date: 2025-03-30T15:00:00.000Z
 draft: false
 publication_date: COMING SOON
 show_3d_transition: true
+description: Upcoming and self-published novels and novellas by Jeffrey A. Zyjeski.
 ---
 My upcoming and self-published novels and novellas!

--- a/content/books/the-protocol-vol1/index.md
+++ b/content/books/the-protocol-vol1/index.md
@@ -8,6 +8,7 @@ pages = 312
 publication_date = 'coming 2025'
 show_3d_transition = true
 tags = ['cyberpunk', 'digital enlightenment', 'consciousness']
+description = 'First volume in The Protocol Series exploring digital enlightenment.'
 
 [[purchase_links]]
 store = 'Amazon'

--- a/content/books/there-are-no-humans.md
+++ b/content/books/there-are-no-humans.md
@@ -9,6 +9,7 @@ show_3d_transition: false
 purchase_links:
   - store: Amazon
     url: https://a.co/d/3QcVVOk
+description: Philosophical novella exploring consciousness in a post-human universe.
 ---
 <!--StartFragment-->
 

--- a/content/inquiries/index.md
+++ b/content/inquiries/index.md
@@ -1,0 +1,8 @@
++++
+title = 'Agent/Editor Inquiries'
+date = 2025-04-30T12:00:00-07:00
+draft = false
+description = 'Contact information for literary agents and editors interested in Jeffrey A. Zyjeski\'s work.'
++++
+
+For agent or editor inquiries, please email [jeff@zyjeski.com](mailto:jeff@zyjeski.com).

--- a/content/inquiries/index.md
+++ b/content/inquiries/index.md
@@ -1,8 +1,8 @@
 +++
-title = 'Agent/Editor Inquiries'
+title = "Agent/Editor Inquiries"
 date = 2025-04-30T12:00:00-07:00
 draft = false
-description = 'Contact information for literary agents and editors interested in Jeffrey A. Zyjeski\'s work.'
+description = "Contact information for literary agents and editors interested in Jeffrey A. Zyjeski's work."
 +++
 
 For agent or editor inquiries, please email [jeff@zyjeski.com](mailto:jeff@zyjeski.com).

--- a/content/newsletter/_index.md
+++ b/content/newsletter/_index.md
@@ -2,6 +2,7 @@
 title = 'Future Law Insider'
 date = 2023-01-01T08:00:00-07:00
 draft = false
+description = 'Monthly newsletter exploring emerging technology and the future of law.'
 +++
 
 Welcome to Future Law Insider, where legal expertise meets forward-thinking speculation. As technology races ahead, the gap between innovation and regulation grows wider. This jurisfiction monthly bridges that divide, helping you understand not just what's happening now, but what it means for our legal future.

--- a/content/posts/_index.md
+++ b/content/posts/_index.md
@@ -2,6 +2,7 @@
 title = 'Dharma Log'
 date = 2025-03-30T08:00:00-07:00
 draft = false
+description = 'Notes on consciousness and technology from Jeffrey A. Zyjeski.'
 +++
 
 Chronicles from the intersection of silicon and soul. The Dharma Log documents insights, questions, and explorations arising from the practice of Neuro-Digital Enlightenment.

--- a/content/posts/first-post/index.md
+++ b/content/posts/first-post/index.md
@@ -3,6 +3,7 @@ title = 'Meditation as Debugging'
 date = 2025-03-25T09:30:00-07:00
 draft = false
 tags = ['meditation', 'programming', 'consciousness']
+description = 'Exploring how meditation parallels debugging code and mind.'
 +++
 
 ## Meditation as Debugging: Runtime Errors in Consciousness

--- a/content/posts/lexspecifica/index.md
+++ b/content/posts/lexspecifica/index.md
@@ -3,6 +3,7 @@ title: "Introducing LexSpecifica"
 date: 2025-04-21T10:00:00-07:00
 draft: false
 tags: ['law', 'digital linguistics', 'cyberpunk', 'future governance']
+description: Tool for generating speculative legal frameworks for fiction writers.
 ---
 
 ![Lex Specifica](/LexSpecifica.png)

--- a/content/stories/Eigenstate/index.md
+++ b/content/stories/Eigenstate/index.md
@@ -5,6 +5,7 @@ draft = false
 tags = ['fiction', 'cyberpunk', 'mysticism']
 # Optional: featured image for the story
 image = "/images/uploads/EC_Cover.png"
+description = 'Cyber-mystic tale where digital reality collapses into awareness.'
 +++
 
 

--- a/content/stories/_index.md
+++ b/content/stories/_index.md
@@ -2,6 +2,7 @@
 title: Short Stories
 date: 2025-03-30T15:00:00.000Z
 draft: false
+description: Experimental fiction exploring digital consciousness and non-duality.
 ---
 Digital-age stories that dissolve the boundaries between machine and consciousness. These brief textual paradoxes are designed to short-circuit dualistic thinking and create momentary glitches in conventional perception.
 

--- a/content/stories/bart-higgins/index.md
+++ b/content/stories/bart-higgins/index.md
@@ -3,6 +3,7 @@ title = "Bart Higgins"
 date = 2025-04-20T10:00:00-07:00
 draft = false
 tags = ['fiction', 'character-study']
+description = 'Slice-of-life story about the laid-back Bart Higgins.'
 +++
 
 Bartholomew Higgins, or Bart as everyone (eventually) called him, came into the world under a sweltering midday sun. His mom, a woman who collected coincidences like some people collect stamps, swore up and down that was the reason he was, well, relaxed. "Born needing a nap," she'd say, shaking her head with a mixture of exasperation and a fondness that, if you looked close enough, you could just barely see. Bart? He took it as a sign from the universe. A permission slip, maybe.

--- a/content/stories/first-koan/index.md
+++ b/content/stories/first-koan/index.md
@@ -4,6 +4,7 @@ date = 2025-01-10T11:00:00-07:00
 draft = false
 koan_text = 'The compiler cannot compile itself until it realizes there is no compiler.'
 tags = ['koans', 'paradox', 'non-duality']
+description = 'Short koan highlighting the paradox of self-referential awareness.'
 +++
 
 In the echo chamber of recursive logic, a student approached the master programmer.

--- a/content/stories/thousand/thousand.md
+++ b/content/stories/thousand/thousand.md
@@ -3,6 +3,7 @@ title = "A Thousand Empty Mirrors"
 date = 2025-04-20T10:00:00-07:00
 draft = false
 tags = ['fiction', 'recursive']
+description = 'Flash fiction exploring recursion and self-reflection.'
 +++
 
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -63,3 +63,8 @@ theme = "AUTHOR"
     name = 'About'
     pageRef = '/about'
     weight = 70
+
+  [[menu.main]]
+    name = 'Agent/Editor Inquiries'
+    pageRef = '/inquiries'
+    weight = 80

--- a/themes/AUTHOR/layouts/_default/baseof.html
+++ b/themes/AUTHOR/layouts/_default/baseof.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ printf "%s | %s" .Title site.Title }}{{ end }}</title>
+  {{ with .Params.description }}
+  <meta name="description" content="{{ . }}">
+  {{ else }}{{ with site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}{{ end }}
   
   <!-- Add mobile viewport and touch icon meta tags -->
   <meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
## Summary
- create **Agent/Editor Inquiries** page and link in site menu
- add page descriptions throughout content for SEO
- output meta description in base template

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3c9a71f083279c1b1bfbf8ef5c5d