### PR TITLE
Add sitewide Coming Soon maintenance page and Netlify redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,18 @@
   to = "https://www.zyjeski.com/:splat"
   status = 301
   force = true
+
+[[redirects]]
+  from = "/coming-soon.html"
+  to = "/coming-soon.html"
+  status = 200
+
+[[redirects]]
+  from = "/*"
+  to = "/coming-soon.html"
+  status = 200
+  force = true
+
 [build]
   publish = "public"
   command = "hugo"

--- a/static/coming-soon.html
+++ b/static/coming-soon.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Coming Soon</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        background: radial-gradient(circle at top, #1f2937 0%, #020617 70%);
+        color: #e2e8f0;
+        text-align: center;
+        padding: 2rem;
+      }
+      main {
+        max-width: 36rem;
+      }
+      h1 {
+        margin: 0 0 1rem;
+        font-size: clamp(2rem, 6vw, 3.5rem);
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+      }
+      p {
+        margin: 0;
+        font-size: clamp(1rem, 3vw, 1.25rem);
+        line-height: 1.6;
+        color: #cbd5e1;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Coming Soon</h1>
+      <p>We&rsquo;re making updates right now. Please check back shortly.</p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation

- Temporarily take the live site offline behind a single maintenance landing page while updates are performed.
- Ensure every incoming path serves the same lightweight, self-contained page so theme/layout dependencies do not interfere with the maintenance view.

### Description

- Add a static maintenance page at `static/coming-soon.html` containing a simple, centered “Coming Soon” message with minimal inline CSS so it can be served without the site build.
- Update `netlify.toml` to add an explicit `/coming-soon.html` route and a forced rewrite from `/*` to `/coming-soon.html` with a `200` status so all requests return the maintenance page.

### Testing

- Attempted to run `hugo --minify`, which failed because `hugo` is not installed in the environment. 
- Served the `static` directory with `python -m http.server 4173 --directory static` and verified the page loads locally. 
- Automated browser validation using Playwright captured a screenshot of `http://127.0.0.1:4173/coming-soon.html`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fe7a94f648327a9ed50272b9bd16a)